### PR TITLE
Add Minecraft-Youtube-Follower to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,4 +257,5 @@ _Miscellaneous tools._
 - [Blockbench](https://github.com/JannisX11/blockbench) - Blockbench is a free, modern model editor for boxy models and pixel art textures.
 - [MultiMC](https://multimc.org/) - MultiMC is a custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once.
 - [PrismLauncher](https://prismlauncher.org/) - A community fork of MultiMC that includes additional features and quality of life improvements.
+- [Minecraft-Youtube-Follower](https://github.com/GeiserX/Minecraft-Youtube-Follower) - A Docker-based system for 24/7 automated Minecraft server streaming with a Mineflayer spectator bot that follows players with a smart third-person camera.
 - [pakkit](https://github.com/Heath123/pakkit) - A packet monitor for Minecraft written in Electron.


### PR DESCRIPTION
Adds [Minecraft-Youtube-Follower](https://github.com/GeiserX/Minecraft-Youtube-Follower) to the Tools section.

It is a Docker-based system for 24/7 automated streaming of Minecraft servers. A Mineflayer spectator bot follows players with a smart third-person camera and streams to YouTube or Twitch.

**Demo streams:**
- https://youtube.com/live/7pPMtL0e8eE
- https://youtube.com/live/9ns0jZ_VBC4