### PR TITLE
Add pluggy under new Developer Tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Feel free to suggest more projects. Only suggest projects you'd recommend to a f
 - [Resources](#resources)
   - [Performance](#performance)
 - [Software](#software)
+  - [Developer Tooling](#developer-tooling)
   - [Tools](#tools)
   - [Proxy Software](#proxy-software)
   - [Server Software](#server-software)
@@ -231,6 +232,11 @@ _Resources for Minecraft performance tuning._
 - [wiki.vg_(minecraft.wiki)](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Main_Page) - Wiki.vg has documented the whole minecraft protocol for java and bedrock edition. _(moved to minecraft.wiki)_
 
 # Software
+
+## Developer Tooling
+_Tools for developing Minecraft plugins and mods._
+
+- [pluggy](https://github.com/pluggy-sh/pluggy) - A standalone CLI for scaffolding, building, and running Minecraft plugin projects across Spigot, Paper, and other server platforms.
 
 ## Proxy Software
 _Minecraft server proxy software._


### PR DESCRIPTION
## Summary

Adds [pluggy](https://github.com/pluggy-sh/pluggy) — a standalone CLI for Minecraft plugin development (scaffolding, fetching server platforms like Spigot/Paper, running dev servers, building artifacts).

It didn't slot cleanly into any existing category:

- Not a **library/framework** — it's a CLI you run, not code you depend on.
- Not a **plugin** or **mod** — it doesn't run on a server or in the client.
- The closest existing bucket was `Software → Tools`, but those entries are end-user tools (Blockbench, MultiMC, PrismLauncher, pakkit), not developer tooling.

So this PR introduces a new `Software → Developer Tooling` subsection. It's a natural home for build tools, scaffolders, and other plugin/mod dev CLIs that don't fit elsewhere, and the section can grow over time. Happy to instead drop pluggy into `Tools` and skip the new subsection if you'd prefer — just let me know.

## Changes

- New `Developer Tooling` entry in the table of contents under `Software`.
- New `## Developer Tooling` subsection in the body, placed before `Proxy Software`.
- One entry: pluggy.